### PR TITLE
Add Object Database synchronization

### DIFF
--- a/src/bin/twig/cli/odb.rs
+++ b/src/bin/twig/cli/odb.rs
@@ -3,7 +3,9 @@ use std::{io, path::PathBuf};
 use clap::Parser;
 use tooling::{
     error::{Error, ErrorExt, ErrorType},
-    model::{odb_driver::FilesystemDriver, Object, ObjectDB, ObjectID, ObjectType},
+    model::{
+        odb_driver::FilesystemDriver, Object, ObjectCompression, ObjectDB, ObjectID, ObjectType,
+    },
     util::fs::{file_create, PathUtil},
 };
 
@@ -35,6 +37,19 @@ enum Command {
 
         /// The path to the file to put into the object database
         path: PathBuf,
+    },
+    /// Pull an object from another object database
+    Pull {
+        /// The path to the other object database root
+        #[arg(long)]
+        other: PathBuf,
+
+        /// Whether to recursively pull dependencies or not
+        #[arg(long, short, action)]
+        recursive: bool,
+
+        /// The object ID of the object to pull
+        object: ObjectID,
     },
     /// Print the dependencies of an object
     Dependencies {
@@ -91,6 +106,21 @@ impl Command {
                     )
                     .e_context(|| format!("Putting {} into object database", path.str_lossy()))?;
                 println!("{}", object.oid);
+            }
+            Command::Pull {
+                other,
+                recursive,
+                object,
+            } => {
+                let other_driver = FilesystemDriver::new(other.clone())?;
+                let other_odb = ObjectDB::init(Box::new(other_driver))?;
+
+                odb.pull(
+                    &other_odb,
+                    object.clone(),
+                    ObjectCompression::Xz,
+                    *recursive,
+                )?;
             }
             Command::Dependencies { tree, oid } => {
                 let object = odb.get_object(oid)?;

--- a/src/model/object/objectdb.rs
+++ b/src/model/object/objectdb.rs
@@ -170,12 +170,20 @@ impl ObjectDB {
 pub enum ObjectDBError {
     /// An object was not found in the database
     ObjectNotFound(ObjectID),
+    ObjectIDMismatch {
+        expected: ObjectID,
+        received: ObjectID,
+    },
 }
 
 impl Display for ObjectDBError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ObjectNotFound(oid) => write!(f, "Object {oid} not found"),
+            Self::ObjectIDMismatch { expected, received } => write!(
+                f,
+                "Object ID mismatch - expected {expected}, got {received}"
+            ),
         }
     }
 }

--- a/src/model/object/objectdb/driver.rs
+++ b/src/model/object/objectdb/driver.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use crate::{
     error::Error,
     model::{Object, ObjectCompression, ObjectID, ObjectReader, ObjectType, SeekRead},
@@ -32,23 +34,64 @@ pub trait ODBDriver {
     fn retrieve(&self, oid: &ObjectID) -> Result<Option<ObjectReader>, Error>;
 }
 
+/// A stream that provides the data of the object to
+/// the object template consumer
+pub enum ObjectTemplateStream<'a> {
+    /// The data is passed normally, the object id is computed
+    /// by seeking the stream and hashing the data
+    Normal(&'a mut dyn SeekRead),
+    /// Data is already prehashed and there is no need to
+    /// seek around in the stream
+    Prehashed {
+        /// The stream providing the data
+        stream: &'a mut dyn Read,
+        /// The object ID that results from hashing the stream
+        oid: ObjectID,
+    },
+}
+
 /// A template to create an object of by inserting it into an object database driver
 pub struct ObjectTemplate<'a> {
-    stream: &'a mut dyn SeekRead,
+    stream: ObjectTemplateStream<'a>,
     ty: ObjectType,
     dependencies: Vec<ObjectID>,
 }
 
 impl<'a> ObjectTemplate<'a> {
-    /// Create a new object database driver
+    /// Create a new object template
+    /// # Arguments
     /// * `stream` - The stream to use as the object data
     /// * `ty` - The type of object at hand
     /// * `dependencies` - The dependencies of the object
     pub fn new(stream: &'a mut dyn SeekRead, ty: ObjectType, dependencies: Vec<ObjectID>) -> Self {
         Self {
-            stream,
+            stream: ObjectTemplateStream::Normal(stream),
             ty,
             dependencies,
         }
+    }
+
+    /// Create a new object template from a prehashed stream
+    /// # Arguments
+    /// * `stream` - The stream to store
+    /// * `oid` - The prehashed object id of the stream
+    /// * `ty` - The object type at hand
+    /// * `dependencies` - The dependencies of the object
+    pub fn new_prehashed(
+        stream: &'a mut dyn Read,
+        oid: ObjectID,
+        ty: ObjectType,
+        dependencies: Vec<ObjectID>,
+    ) -> Self {
+        Self {
+            stream: ObjectTemplateStream::Prehashed { stream, oid },
+            ty,
+            dependencies,
+        }
+    }
+
+    /// Splits the template up into its stream, type and dependencies
+    pub fn split_up(self) -> (ObjectTemplateStream<'a>, ObjectType, Vec<ObjectID>) {
+        (self.stream, self.ty, self.dependencies)
     }
 }

--- a/src/model/object/objectdb/driver.rs
+++ b/src/model/object/objectdb/driver.rs
@@ -32,6 +32,11 @@ pub trait ODBDriver {
     /// # Returns
     /// The object or `None` if it is not found
     fn retrieve(&self, oid: &ObjectID) -> Result<Option<ObjectReader>, Error>;
+
+    /// Returns whether this driver contains the object with `oid`
+    /// # Arguments
+    /// * `oid` - The object id to search for
+    fn exists(&self, oid: &ObjectID) -> bool;
 }
 
 /// A stream that provides the data of the object to

--- a/src/model/object/objectdb/driver/odb_driver/odb_fs_driver.rs
+++ b/src/model/object/objectdb/driver/odb_driver/odb_fs_driver.rs
@@ -85,4 +85,10 @@ impl ODBDriver for FilesystemDriver {
             ObjectReader::from_stream(file).ctx(|| "Reading object")?,
         ))
     }
+
+    fn exists(&self, oid: &ObjectID) -> bool {
+        let file_path = self.get_oid_path(oid);
+
+        file_path.exists()
+    }
 }

--- a/src/model/object/objectdb/driver/odb_driver/odb_fs_driver.rs
+++ b/src/model/object/objectdb/driver/odb_driver/odb_fs_driver.rs
@@ -52,24 +52,18 @@ impl FilesystemDriver {
 impl ODBDriver for FilesystemDriver {
     fn insert(
         &mut self,
-        mut object_template: ObjectTemplate,
+        object_template: ObjectTemplate,
         compression: ObjectCompression,
     ) -> Result<Object, Error> {
         let temp_file_path = self.get_temp_file_path();
         fs::create_parent_dir_all(&temp_file_path)
             .ctx(|| "Creating temporary object file parent")?;
 
-        let mut temp_file =
+        let temp_file =
             fs::file_create(&temp_file_path).ctx(|| "Creating temporary object file")?;
 
-        let object = Object::create_from_stream(
-            &mut object_template.stream,
-            &mut temp_file,
-            object_template.dependencies,
-            object_template.ty,
-            compression,
-        )
-        .ctx(|| "Creating object file")?;
+        let object = Object::create_from_template(object_template, temp_file, compression)
+            .ctx(|| "Creating object file")?;
 
         let file_path = self.get_oid_path(&object.oid);
         fs::create_parent_dir_all(&file_path).ctx(|| "Creating object parent directory")?;


### PR DESCRIPTION
This PR adds ODB syncing facilities.
This manifests itself in the `ObjectDB::pull()` function that can pull objects (recursively) from another object database.